### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/rockspecs.lua
+++ b/rockspecs.lua
@@ -19,7 +19,7 @@ default = {
   package = "Lrexlib-"..flavour,
   version = version.."-1",
   source = {
-    url = "git://github.com/rrthomas/lrexlib.git",
+    url = "git+https://github.com/rrthomas/lrexlib.git",
     tag = "rel-"..version_dashed,
   },
   description = {


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/