### PR TITLE
Mark a global variable not in a header as static

### DIFF
--- a/src/pcre/lpcre.c
+++ b/src/pcre/lpcre.c
@@ -81,7 +81,7 @@ static void do_named_subpatterns (lua_State *L, TPcre *ud, const char *text);
 #define INDEX_CHARTABLES_META  1      /* chartables type's metatable */
 #define INDEX_CHARTABLES_LINK  2      /* link chartables to compiled regex */
 
-const char chartables_typename[] = "chartables";
+static const char chartables_typename[] = "chartables";
 
 /*  Functions
  ******************************************************************************

--- a/src/pcre2/lpcre2.c
+++ b/src/pcre2/lpcre2.c
@@ -80,7 +80,7 @@ static void do_named_subpatterns (lua_State *L, TPcre2 *ud, const char *text);
 #define INDEX_CHARTABLES_META  1      /* chartables type's metatable */
 #define INDEX_CHARTABLES_LINK  2      /* link chartables to compiled regex */
 
-const char chartables_typename[] = "chartables";
+static const char chartables_typename[] = "chartables";
 
 /*  Functions
  ******************************************************************************


### PR DESCRIPTION
The global const char array chartables_typename can be made static, which avoids having it be an externally visibile symbol. (It's contained in both the PCRE and PCRE2 backends, but those are different translation units so these are different copies of the string, not shared.) It's not declared in a header file so it's probably not meant to be externally visible. This prevents some warnings like

[105/3376] Building C object epan/wslua/lrexlib/CMakeFiles/lrexlib.dir/pcre2/lpcre2.c.o epan/wslua/lrexlib/pcre2/lpcre2.c:101:12: warning: no previous extern declaration for non-static variable 'chartables_typename' [-Wmissing-variable-declarations]
  101 | const char chartables_typename[] = "chartables";
      |            ^
epan/wslua/lrexlib/pcre2/lpcre2.c:101:7: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  101 | const char chartables_typename[] = "chartables";
      |       ^
1 warning generated.

when the -Wmissing-variable-declarations warning is enabled in Clang or recent GCC.